### PR TITLE
Automated Changelog Entry for 0.2.0.dev2 on jupyter-releaser

### DIFF
--- a/.github/workflows/check_release.yaml
+++ b/.github/workflows/check_release.yaml
@@ -7,6 +7,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+
 jobs:
   check_release:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.2.0.dev2
+
+No merged PRs
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## v0.2.0.dev0
 
 ([full changelog](https://github.com/trungleduc/ipyflex/compare/v0.1.2...4ef8f0fd954508e5239387fa95208a3d9eb9d22c))
@@ -16,8 +22,6 @@
 ([GitHub contributors page for this release](https://github.com/trungleduc/ipyflex/graphs/contributors?from=2021-11-29&to=2021-12-15&type=c))
 
 [@github-actions](https://github.com/search?q=repo%3Atrungleduc%2Fipyflex+involves%3Agithub-actions+updated%3A2021-11-29..2021-12-15&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Atrungleduc%2Fipyflex+involves%3Atrungleduc+updated%3A2021-11-29..2021-12-15&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## v0.1.2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,5 +22,8 @@ message_template = "Bump to {new_version}"
 tag_template = "v{new_version}"
 
 [tool.jupyter-releaser.hooks]
-before-bump-version = ["python -m pip install jupyterlab~=3.0"]
+before-bump-version = ["python -m pip install jupyterlab~=3.0 jupyter_packaging~=0.10"]
 before-build-npm = ["python -m pip install jupyterlab~=3.0", "jlpm clean", "jlpm build:prod"]
+
+[tool.check-manifest]
+ignore = [".binder/**", "docs/**", "examples/**", "*.json", "*.gif", "yarn.lock", "environment.yml", "readthedocs.yml", ".*", "ipyflex/labextension/**", "ipyflex/labextension/index*", "tests/**", "ui-tests/**", "CHANGELOG.md", "babel.config.js", "codecov.yml", "jest.config.js", "tsconfig.eslint.json"]


### PR DESCRIPTION
Automated Changelog Entry for 0.2.0.dev2 on jupyter-releaser
```
Python version: 0.2.0.dev2
npm version: ipyflex: 0.2.0-dev.1
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | trungleduc/ipyflex  |
| Branch  | jupyter-releaser  |
| Version Spec | next |
| Since | v0.1.2 |