### PR TITLE
Update non-editable mode

### DIFF
--- a/src/defaultModelFactory.ts
+++ b/src/defaultModelFactory.ts
@@ -101,9 +101,12 @@ export function updateModelEditable(model: IDict, editable: boolean): IDict {
     tabEnableRename: editable,
     tabEnableClose: editable,
     tabSetEnableClose: editable,
+    tabSetEnableMaximize: editable,
     tabEnableDrag: editable,
     tabSetEnableDrag: editable,
   };
+  let splitterSize: number;
+  editable ? (splitterSize = 8) : (splitterSize = 0);
   if ('global' in model) {
     model.global = { ...globaleDict, tabSetTabLocation: 'bottom' };
   }
@@ -114,6 +117,7 @@ export function updateModelEditable(model: IDict, editable: boolean): IDict {
       child['config']['model']['global'] = {
         ...globaleDict,
         ...child['config']['model']['global'],
+        splitterSize,
       };
     }
   }

--- a/src/reactWidget.tsx
+++ b/src/reactWidget.tsx
@@ -459,12 +459,12 @@ export class FlexWidget extends Component<IProps, IState> {
     const contextMenu = new ContextMenu({ commands });
     contextMenu.addItem({
       command: 'show-tab-bar',
-      selector: selector,
+      selector: this.props.editable ? selector : 'null',
       rank: 0,
     });
     contextMenu.addItem({
       command: 'hide-tab-bar',
-      selector: selector,
+      selector: this.props.editable ? selector : 'null',
       rank: 1,
     });
     return contextMenu;
@@ -484,6 +484,11 @@ export class FlexWidget extends Component<IProps, IState> {
       }
       if (titleProps['buttons'] === true) {
         titleProps['buttons'] = ['save', 'export', 'import'];
+      }
+      if (!this.props.editable) {
+        titleProps['buttons'] = (titleProps['buttons'] as Array<string>).filter(
+          (btn) => btn !== 'save'
+        );
       }
     }
     return (

--- a/src/reactWidget.tsx
+++ b/src/reactWidget.tsx
@@ -501,7 +501,7 @@ export class FlexWidget extends Component<IProps, IState> {
         <div
           style={{
             width: '100%',
-            height: this.state.editable ? mainHeight : '100%',
+            height: mainHeight,
             position: 'relative',
           }}
         >


### PR DESCRIPTION
In non-editable mode:

- Disable tab resize 
- Hide context menu and save template button.