### PR TITLE
Automated Changelog Entry for 0.2.5 on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.2.5
+
+([Full Changelog](https://github.com/trungleduc/ipyflex/compare/v0.2.4...d6e5da42042d7a05b859b4b53f89d3d0d1b4b747))
+
+### Merged PRs
+
+- Support ipywidgets 8 [#48](https://github.com/trungleduc/ipyflex/pull/48) ([@trungleduc](https://github.com/trungleduc))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/trungleduc/ipyflex/graphs/contributors?from=2022-09-15&to=2022-10-25&type=c))
+
+[@github-actions](https://github.com/search?q=repo%3Atrungleduc%2Fipyflex+involves%3Agithub-actions+updated%3A2022-09-15..2022-10-25&type=Issues) | [@trungleduc](https://github.com/search?q=repo%3Atrungleduc%2Fipyflex+involves%3Atrungleduc+updated%3A2022-09-15..2022-10-25&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.2.4
 
 ([Full Changelog](https://github.com/trungleduc/ipyflex/compare/v0.2.3...2e62bc9b5c5209ee8a643502855ad339d446a169))
@@ -15,8 +31,6 @@
 ([GitHub contributors page for this release](https://github.com/trungleduc/ipyflex/graphs/contributors?from=2022-09-15&to=2022-09-15&type=c))
 
 [@trungleduc](https://github.com/search?q=repo%3Atrungleduc%2Fipyflex+involves%3Atrungleduc+updated%3A2022-09-15..2022-09-15&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.2.3
 


### PR DESCRIPTION
Automated Changelog Entry for 0.2.5 on master
```
Python version: 0.2.5
npm version: ipyflex: 0.2.4
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | trungleduc/ipyflex  |
| Branch  | master  |
| Version Spec | 0.2.5 |
| Since | v0.2.4 |